### PR TITLE
Update auth grep expression

### DIFF
--- a/manifests/registry.pp
+++ b/manifests/registry.pp
@@ -65,7 +65,7 @@ define docker::registry(
   exec { "${title} auth":
     environment => $auth_environment,
     command     => $auth_cmd,
-    unless      => "grep -qPaz '(\^.*)\"auths\": {\\n.*\"${server}\": {\\n\\s+\"auth\": \"${auth_string}\"' ~${local_user}/.docker/config.json",
+    unless      => "grep -qPaz '\"auths\": {\\n\\s+\"${server}\": {\\n\\s+\"auth\": \"${auth_string}\"' ~${local_user}/.docker/config.json",
     user        => $local_user,
     cwd         => '/root',
     path        => ['/bin', '/usr/bin', '/usr/local/bin/' ],


### PR DESCRIPTION
Skip the beginning of line business (^) and use the same expression to match leading spaces on both lines.